### PR TITLE
Bugfix for Issue #75 OAuth1 Signature error

### DIFF
--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -999,8 +999,17 @@ class OAuth extends ApiAuth implements AuthInterface
      */
     private function normalizeParameters($parameters, $encode = false, $returnarray = false, $normalized = array(), $key = '')
     {
-        //Sort by key
-        ksort($parameters);
+        // December 2016 - Fix for issue #75
+        //
+        // recursive call identified by these 2 conditions.
+        if ($returnarray && ('' != $key)) {
+            // Ref: Spec: 9.1.1 (1)
+            // If two or more parameters share the same name, they are sorted by their value
+            sort($parameters, SORT_STRING);
+        } else {
+            // Sort by key
+            ksort($parameters);
+        }
 
         foreach ($parameters as $k => $v) {
             if (is_array($v)) {


### PR DESCRIPTION
This PR addresses Issue https://github.com/mautic/api-library/issues/75 which is an error in the normalization of the Signing-String.

To test this PR, create a unit test to create a new contact and use the data example from the Issue to test. Without this fix, the second example will fail with a signature error. After this PR is installed the test case should now pass. Without this fix, several tests failed with oauth1 and Mautic 2.4.0.